### PR TITLE
[Workflow] Changesets prerelease

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,12 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "powersync-example": "1.0.0",
+    "@journeyapps/react-native-quick-sqlite": "0.0.1-alpha.0",
+    "@journeyapps/powersync-react": "0.0.1-alpha.0",
+    "@journeyapps/powersync-sdk-common": "0.0.1-alpha.0",
+    "@journeyapps/powersync-sdk-react-native": "0.0.1-alpha.1"
+  },
+  "changesets": []
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tsconfig.tsbuildinfo
 yarn-error.log
 .vscode
 .DS_STORE
+.idea


### PR DESCRIPTION
This PR puts Changesets into a prerelease mode in order to keep package versions consistent with the current `-alpha.x` versioning. 

Running `changeset version` in the next version PR will bump packages as below
<img width="627" alt="image" src="https://github.com/journeyapps/powersync-react-native-sdk/assets/51082125/41ac76e3-dccb-4f93-8ea9-8e4e60c2d443">
